### PR TITLE
Fix vendor info in manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,11 +111,11 @@ jar {
     manifest {
         attributes([
                 "Specification-Title"     : "socketnukes",
-                "Specification-Vendor"    : "socketsmods",
+                "Specification-Vendor"    : "socketmods",
                 "Specification-Version"   : "1",
                 "Implementation-Title"    : project.name,
                 "Implementation-Version"  : version,
-                "Implementation-Vendor"   : "socketsmods",
+                "Implementation-Vendor"   : "socketmods",
                 "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
                 "Git-Commit"              : commit_id,
                 "Git-Commit-Timestamp"    : git_timestamp


### PR DESCRIPTION
Fixes the vendor entries in the manifest, from `socketsmods` to `socketmods`.