### PR TITLE
Move version calculation to external script, improve package-info task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,16 +97,6 @@ dependencies {
     dataImplementation sourceSets.main.output
 }
 
-def commit_id = "unknown"
-def git_timestamp = "unknown"
-try {
-    commit_id = grgit.head().id
-    def datetime = grgit.head().dateTime
-    git_timestamp = datetime.toLocalDateTime().toString() + datetime.getOffset().toString().replace(':', '')
-} catch (Exception e) {
-    logger.error("Error while trying to get commit info: {}", e.toString())
-}
-
 jar {
     finalizedBy 'reobfJar'
     manifest {
@@ -118,8 +108,8 @@ jar {
                 "Implementation-Version"  : version,
                 "Implementation-Vendor"   : "socketmods",
                 "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
-                "Git-Commit"              : commit_id,
-                "Git-Commit-Timestamp"    : git_timestamp
+                "Git-Commit"              : getCommitHash(),
+                "Git-Commit-Timestamp"    : getCommitTimestamp()
         ] as LinkedHashMap)
     }
     includeEmptyDirs false

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,10 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.ajoberstar.grgit'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
+apply from: 'utils/version.gradle'
 apply from: 'utils/package-info.gradle'
 
-version = getVersion()
+version = calculateVersion()
 println('Mod version: ' + version)
 group = 'dev.socketmods.socketnukes'
 archivesBaseName = "socketnukes-${mc_version}"
@@ -136,38 +137,4 @@ publishing {
             url "file:///${project.projectDir}/mcmodsrepo"
         }
     }
-}
-
-static boolean isMainBranch(String branchName) {
-    return branchName.equals("HEAD") || branchName.equals("main") || branchName.matches("\\d+.\\d+.[\\dx]+")
-}
-
-String getVersion() {
-    try {
-        final String branchName = grgit.branch.current().name
-        boolean nonMainBranch = !isMainBranch(branchName)
-        if (nonMainBranch) println("Currently on non-main branch: " + branchName)
-        String ver = grgit.describe(commit: grgit.head(), longDescr: true, tags: true)
-        if (ver == null) throw new RuntimeException("Could not retrieve version information from grgit")
-
-        String[] split = ver.split("-")
-
-        String tag = split[0]
-        String commitCount = split[1]
-        String commitHash = split[2]
-        if (tag.startsWith("v")) tag = tag.substring(1) // Remove 'v' prefixes from tags
-
-        boolean hasClassifier = release_type != null && !release_type.equals("release")
-
-        String version = "${tag}.${commitCount}"
-        // Append classifier if it exists
-        if (hasClassifier) version += "-${release_type}"
-        // Append branch and commit hash if not on main branch
-        if (nonMainBranch) version += "-${commitHash}-${branchName}"
-
-        return version
-    } catch (Exception e) {
-        logger.error("Error while getting version information: {}", e)
-    }
-    return "unknown"
 }

--- a/utils/package-info.gradle
+++ b/utils/package-info.gradle
@@ -41,6 +41,11 @@ task generatePackageInfos() {
     }
 }
 
+// Always generate the package-infos when any of the javas
+tasks.withType(JavaCompile) {
+    dependsOn generatePackageInfos
+}
+
 static String generatePackageInfo(String packageName) {
     return """@MethodsReturnNonnullByDefault
              |@ParametersAreNonnullByDefault

--- a/utils/package-info.gradle
+++ b/utils/package-info.gradle
@@ -18,6 +18,7 @@ task generatePackageInfos() {
                 .collect(Collectors.toList())
 
         sourceDirectories.forEach { sourceDirectory ->
+            if (!sourceDirectory.exists()) return
             sourceDirectory.eachDirRecurse { directory ->
                 // If file contains java source files
                 def files = directory.list { _, name -> name.endsWith(".java") }
@@ -30,7 +31,7 @@ task generatePackageInfos() {
 
                 // Skip if package-info.java exists and contains the expected string
                 def packageInfo = new File(directory, "package-info.java")
-                if (packageInfo.exists() && packageString.replace('\r\n', '\n').equals(packageInfo.text)) return
+                if (packageInfo.exists() && packageString.equals(packageInfo.text.replace('\r\n', '\n'))) return
 
                 // Write package-info.java
                 logger.info "Writing package-info.java for: $packageInfo"

--- a/utils/package-info.gradle
+++ b/utils/package-info.gradle
@@ -41,7 +41,7 @@ task generatePackageInfos() {
     }
 }
 
-// Always generate the package-infos when any of the javas
+// Always generate the package-infos for all of the compile tasks
 tasks.withType(JavaCompile) {
     dependsOn generatePackageInfos
 }

--- a/utils/package-info.gradle
+++ b/utils/package-info.gradle
@@ -23,7 +23,7 @@ task generatePackageInfos() {
                 def files = directory.list { _, name -> name.endsWith(".java") }
                 if (files == null || files.size() == 0) return
 
-                println "[PackageInfo] Visiting: $directory"
+                logger.debug "Visiting $directory for package-info.java"
 
                 // Create package-info string
                 def packageString = generatePackageInfo(getPackageName(sourceDirectory, directory))
@@ -33,7 +33,7 @@ task generatePackageInfos() {
                 if (packageInfo.exists() && packageString.replace('\r\n', '\n').equals(packageInfo.text)) return
 
                 // Write package-info.java
-                println "[PackageInfo] Writing: $packageInfo"
+                logger.info "Writing package-info.java for: $packageInfo"
                 if (packageInfo.exists()) packageInfo.delete()
                 packageInfo.write(packageString)
             }

--- a/utils/package-info.gradle
+++ b/utils/package-info.gradle
@@ -1,4 +1,4 @@
-import java.nio.file.Paths
+import java.util.stream.Collectors
 
 /**
  *  Generates package-info.java for appropriate packages
@@ -12,11 +12,10 @@ task generatePackageInfos() {
     outputs.upToDateWhen { false }
 
     doLast {
-        // TODO: Base off of SourceSets rather than hardcoded paths
-        def sourceDirectories = [
-                file(Paths.get(projectDir.absolutePath, "src", "main", "java")),
-                file(Paths.get(projectDir.absolutePath, "src", "data", "java")),
-        ]
+        def sourceDirectories = sourceSets.stream()
+                .map { source -> source.java.srcDirs }
+                .flatMap { fileSet -> fileSet.stream() }
+                .collect(Collectors.toList())
 
         sourceDirectories.forEach { sourceDirectory ->
             sourceDirectory.eachDirRecurse { directory ->
@@ -26,13 +25,17 @@ task generatePackageInfos() {
 
                 println "[PackageInfo] Visiting: $directory"
 
-                // And package-info.java doesn't exist
-                def packageInfo = new File(directory, "package-info.java")
-                if (packageInfo.exists()) return
+                // Create package-info string
+                def packageString = generatePackageInfo(getPackageName(sourceDirectory, directory))
 
-                // Create package-info.java
-                println "[PackageInfo] Creating: $packageInfo"
-                packageInfo.write(generatePackageInfo(getPackageName(sourceDirectory, directory)))
+                // Skip if package-info.java exists and contains the expected string
+                def packageInfo = new File(directory, "package-info.java")
+                if (packageInfo.exists() && packageString.replace('\r\n', '\n').equals(packageInfo.text)) return
+
+                // Write package-info.java
+                println "[PackageInfo] Writing: $packageInfo"
+                if (packageInfo.exists()) packageInfo.delete()
+                packageInfo.write(packageString)
             }
         }
     }

--- a/utils/version.gradle
+++ b/utils/version.gradle
@@ -1,0 +1,51 @@
+/**
+ * Checks if the given branch name is a main branch, and therefore should not have the commit and branch
+ * information in the version.
+ * @param branchName the branch name to check
+ * @return If the version should not contain the commit and branch information
+ */
+static boolean isMainBranch(String branchName) {
+    return branchName.equals("HEAD") || branchName.equals("main") || branchName.matches("\\d+.\\d+.[\\dx]+")
+}
+
+/**
+ * Calculates the version string, based on the current commit and branch, nearest tag, and release type.
+ *
+ * If there is an exception while calculating the version information (such as Grgit being absent), the
+ * returned version shall be "unknown".
+ *
+ * @return The calculated version string
+ */
+String calculateVersion() {
+    try {
+        final String branchName = grgit.branch.current().name
+        boolean nonMainBranch = !isMainBranch(branchName)
+        if (nonMainBranch) println("Currently on non-main branch: " + branchName)
+        String ver = grgit.describe(commit: grgit.head(), longDescr: true, tags: true)
+        if (ver == null) throw new RuntimeException("Could not retrieve version information from grgit")
+
+        String[] split = ver.split("-")
+
+        String tag = split[0]
+        String commitCount = split[1]
+        String commitHash = split[2]
+        if (tag.startsWith("v")) tag = tag.substring(1) // Remove 'v' prefixes from tags
+
+        boolean hasClassifier = release_type != null && !release_type.equals("release")
+
+        String version = "${tag}.${commitCount}"
+        // Append classifier if it exists
+        if (hasClassifier) version += "-${release_type}"
+        // Append branch and commit hash if not on main branch
+        if (nonMainBranch) version += "-${commitHash}-${branchName}"
+
+        return version
+    } catch (Exception e) {
+        logger.error("Error while getting version information: {}", e)
+    }
+    return "unknown"
+}
+
+ext {
+    calculateVersion = this.&calculateVersion
+}

--- a/utils/version.gradle
+++ b/utils/version.gradle
@@ -46,6 +46,48 @@ String calculateVersion() {
     return "unknown"
 }
 
+ext.commit_id = null
+ext.commit_timestamp = null
+
+/**
+ * Returns the hash of the current commit.
+ *
+ * Retrieves both the hash and timestamp from the current commit, and stores both.
+ * If there is an error retrieving the hash or the timestamp, it will be left as "unknown".
+ *
+ * @return The current commit hash, or "unknown"
+ */
+String getCommitHash() {
+    if (ext.commit_id == null) {
+        ext.commit_id = "unknown"
+        ext.commit_timestamp = "unknown"
+        try {
+            ext.commit_id = grgit.head().id
+            def datetime = grgit.head().dateTime
+            ext.commit_timestamp = datetime.toLocalDateTime().toString() + datetime.getOffset().toString().replace(':', '')
+        } catch (Exception e) {
+            logger.error("Error while trying to get commit info: {}", e.toString())
+        }
+    }
+    return ext.commit_id
+}
+
+/**
+ * Returns the timestamp of the current commit.
+ *
+ * Internally calls {@code getCommitHash( )} to retrieve the hash and timestamp first, if not already stored.
+ *
+ * @return The current commit timestamp, or "unknown"
+ */
+String getCommitTimestamp() {
+    if (ext.commit_timestamp == null) {
+        getCommitHash()
+    }
+    return ext.commit_timestamp
+}
+
 ext {
     calculateVersion = this.&calculateVersion
+    getCommitHash = this.&getCommitHash
+    getCommitTimestamp = this.&getCommitTimestamp
 }


### PR DESCRIPTION
* **Move the version calcaulation function to an external script file, alongside `utils/package-info.gradle`**
  * This makes the main build.gradle smaller (and more readable at first glance)
* **Improve `generatePackageInfos` task**
  * Remove hardcoding of java source paths, in favor of dynamically fetching from current sourceSets
    * Now this is future-proofed if we add an `api` source set in the future
    * Current side-effect is that the `test` source set is also visited by the task
  * Make the task also write if the `package-info.java` content's differs from the expected contents
    * Now any rogue auto-formatting that changes the package-infos can be corrected with the running of the task
    * _We should also consider adding this as a task dependency to `compileJava` too, so the package-infos are always clean_
    * Contributing policy should now be that `generatePackageInfos` should be ran before committing to make sure that package-infos are clean (and new packages are populated)